### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/jahi0598/03904722-da5c-42b7-918e-19fe3268d0a7/7cf4a9ba-9224-4ffc-95ce-22cd136c01ba/_apis/work/boardbadge/74aa707a-78a0-4f5c-b5fa-88584929fef7)](https://dev.azure.com/jahi0598/03904722-da5c-42b7-918e-19fe3268d0a7/_boards/board/t/7cf4a9ba-9224-4ffc-95ce-22cd136c01ba/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/jahi0598/03904722-da5c-42b7-918e-19fe3268d0a7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.